### PR TITLE
Remove duplicated step in publish workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -62,9 +62,7 @@ jobs:
         env:
           TWINE_USERNAME: __token__
           TWINE_PASSWORD: ${{ secrets.twine_token }}
-        run: |
-          uv run pyproject-build
-          uv run twine upload --verbose --repository ${{ inputs.repository }} dist/*
+        run: uv run twine upload --verbose --repository ${{ inputs.repository }} dist/*
       - name: highlight
         # TODO: update package name in summary text
         run: |


### PR DESCRIPTION
Simplified publish step by removing unnecessary build command.